### PR TITLE
Add support for file info records (#33)

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -79,6 +79,9 @@ func Translate(c *Config) error {
 	if err := writeTOC(bfd, toc); err != nil {
 		return err
 	}
+	if err := writeInfoTOC(bfd, toc); err != nil {
+		return err
+	}
 	// Write hierarchical tree of assets
 	return writeTOCTree(bfd, toc)
 }

--- a/release.go
+++ b/release.go
@@ -81,6 +81,8 @@ func header_compressed_nomemcopy(w io.Writer) error {
 	"reflect"
 	"strings"
 	"unsafe"
+	"os"
+	"time"
 )
 
 func bindata_read(data, name string) ([]byte, error) {
@@ -119,6 +121,8 @@ func header_compressed_memcopy(w io.Writer) error {
 	"fmt"
 	"io"
 	"strings"
+	"os"
+	"time"
 )
 
 func bindata_read(data []byte, name string) ([]byte, error) {
@@ -148,6 +152,8 @@ func header_uncompressed_nomemcopy(w io.Writer) error {
 	"reflect"
 	"strings"
 	"unsafe"
+	"os"
+	"time"
 )
 
 func bindata_read(data, name string) ([]byte, error) {
@@ -169,6 +175,8 @@ func header_uncompressed_memcopy(w io.Writer) error {
 	_, err := fmt.Fprintf(w, `import (
 	"fmt"
 	"strings"
+	"os"
+	"time"
 )
 `)
 	return err


### PR DESCRIPTION
I needed file modification dates so I could serve assets over go's HTTP server reliably. This implements #33.

Basically I added another function `AssetInfo` that's a lot like `Asset`. There's a chance of breaking backwards compatibility, but only if someone already had a function named `AssetInfo` in their code.

Not sure if this is what you want for a final version, but maybe it can be a starting place.