### PR TITLE
add -dev flag, similar to -debug but does not emit absolute file paths

### DIFF
--- a/config.go
+++ b/config.go
@@ -117,6 +117,16 @@ type Config struct {
 	// in the code. The default behaviour is Release mode.
 	Debug bool
 
+	// Perform a dev build, which is nearly identical to the debug option. The
+	// only difference is that instead of absolute file paths in generated code,
+	// it expects a variable, `rootDir`, to be set in the generated code's
+	// package (the author needs to do this manually), which it then prepends to
+	// an asset's name to construct the file path on disk.
+	//
+	// This is mainly so you can push the generated code file to a shared
+	// repository.
+	Dev bool
+
 	// Recursively process all assets in the input directory and its
 	// sub directories. This defaults to false, so only files in the
 	// input directory itself are read.

--- a/convert.go
+++ b/convert.go
@@ -63,8 +63,8 @@ func Translate(c *Config) error {
 	}
 
 	// Write assets.
-	if c.Debug {
-		err = writeDebug(bfd, toc)
+	if c.Debug || c.Dev {
+		err = writeDebug(bfd, c, toc)
 	} else {
 		err = writeRelease(bfd, c, toc)
 	}

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -7,11 +7,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/jteeuwen/go-bindata"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/jteeuwen/go-bindata"
 )
 
 func main() {
@@ -40,6 +41,7 @@ func parseArgs() *bindata.Config {
 	}
 
 	flag.BoolVar(&c.Debug, "debug", c.Debug, "Do not embed the assets, but provide the embedding API. Contents will still be loaded from disk.")
+	flag.BoolVar(&c.Dev, "dev", c.Dev, "Similar to debug, but does not emit absolute paths. Expects a rootDir variable to already exist in the generated code's package.")
 	flag.StringVar(&c.Tags, "tags", c.Tags, "Optional set of build tags to include.")
 	flag.StringVar(&c.Prefix, "prefix", c.Prefix, "Optional path prefix to strip off asset names.")
 	flag.StringVar(&c.Package, "pkg", c.Package, "Package name to use in the generated code.")


### PR DESCRIPTION
First of all, thanks for making this awesome library. It's been really useful so far, so thanks for making it.

Here's the use case this PR addresses: I want to make it easy for other people to clone and build my repository, which contains a generated `bindata.go` file. If I generate a release `bindata.go`, it will run when they first `go get` it, but they have to run `go-bindata -debug` themselves when developing, which is clunky and they might accidentally commit those changes. If I generate a debug `bindata.go`, the file contains absolute paths unique to my environment, so it'll break on their machine. The proposal is to add a `-dev` flag which is similar to the `-debug` flag, but avoids generating absolute paths. To get around this, it expects there to be a `rootDir` variable in the same package as the generated code.

For an example of this in practice, see:
https://github.com/sourcegraph/apptrace/blob/master/Makefile (a Makefile which contains the `go-bindata -dev` command)
https://github.com/sourcegraph/apptrace/blob/master/traceapp/tmpl/data.go (the auto-generated code file)
https://github.com/sourcegraph/apptrace/blob/master/traceapp/tmpl/data_src.go (a manually created code file which provides the `rootDir` variable)

Let me know if this is functionality you want to support, and if there's any feedback on how to do this better. Thanks!