### PR TITLE
Remove unused field in Config.

### DIFF
--- a/config.go
+++ b/config.go
@@ -127,11 +127,6 @@ type Config struct {
 	// repository.
 	Dev bool
 
-	// Recursively process all assets in the input directory and its
-	// sub directories. This defaults to false, so only files in the
-	// input directory itself are read.
-	Recursive bool
-
 	// Ignores any filenames matching the regex pattern specified, e.g.
 	// path/to/file.ext will ignore only that file, or \\.gitignore
 	// will match any .gitignore file.
@@ -147,7 +142,6 @@ func NewConfig() *Config {
 	c.NoMemCopy = false
 	c.NoCompress = false
 	c.Debug = false
-	c.Recursive = false
 	c.Output = "./bindata.go"
 	c.Ignore = make([]*regexp.Regexp, 0)
 	return c


### PR DESCRIPTION
Commit 2c7ab48825ee496d1020f8fa505c8860f8b95120 added new struct `InputConfig` which contains `Path` string and `Recursive` bool. The rest of `go-bindata` has been changed to use that.

The `Recursive` flag inside `Config` is now completely unused, and should be removed since it makes code harder to read.