### PR TITLE
add `mode` and `modTime` flags

### DIFF
--- a/config.go
+++ b/config.go
@@ -127,6 +127,11 @@ type Config struct {
 	// repository.
 	Dev bool
 
+	// When nonzero, use this as mode for all files.
+	Mode uint
+	// When nonzero, use this as unix timestamp for all files.
+	ModTime int64
+
 	// Ignores any filenames matching the regex pattern specified, e.g.
 	// path/to/file.ext will ignore only that file, or \\.gitignore
 	// will match any .gitignore file.

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -47,6 +47,8 @@ func parseArgs() *bindata.Config {
 	flag.StringVar(&c.Package, "pkg", c.Package, "Package name to use in the generated code.")
 	flag.BoolVar(&c.NoMemCopy, "nomemcopy", c.NoMemCopy, "Use a .rodata hack to get rid of unnecessary memcopies. Refer to the documentation to see what implications this carries.")
 	flag.BoolVar(&c.NoCompress, "nocompress", c.NoCompress, "Assets will *not* be GZIP compressed when this flag is specified.")
+	flag.UintVar(&c.Mode, "mode", c.Mode, "Optional file mode override for all files.")
+	flag.Int64Var(&c.ModTime, "modtime", c.ModTime, "Optional modification unix timestamp override for all files.")
 	flag.StringVar(&c.Output, "o", c.Output, "Optional name of the output file to be generated.")
 	flag.BoolVar(&version, "version", false, "Displays version information.")
 


### PR DESCRIPTION
In some situations, it is desired to have reproducible runs of `go-bindata`
from a fixed git repository commit. Since mtimes and file modes are not
generally versioned, the newly introduced flags aid in that quest by allowing
to completely replace those two pieces of data by something fixed.

Example:
//go:generate go-bindata -pkg resource -mode 0644 -modtime 1388530800 \
                         -o ./embedded.go ./ui/...