### PR TITLE
Always split by forward slashes when writing the TOC tree.

### DIFF
--- a/toc.go
+++ b/toc.go
@@ -7,7 +7,6 @@ package bindata
 import (
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 )
@@ -130,7 +129,7 @@ func AssetDir(name string) ([]string, error) {
 	}
 	tree := newAssetTree()
 	for i := range toc {
-		pathList := strings.Split(toc[i].Name, string(os.PathSeparator))
+		pathList := strings.Split(toc[i].Name, "/")
 		tree.Add(pathList, toc[i])
 	}
 	return tree.WriteAsGoMap(w)


### PR DESCRIPTION
I had a problem where `_bintree` was always a flat hierarchy on Windows which resulted in being unable to use `AssetDir()`.

When I ran `go-bindata test-migrations` on Linux, `_bintree` in the generated file looked like this:

```go
var _bintree = &_bintree_t{nil, map[string]*_bintree_t{
    "test-migrations": &_bintree_t{nil, map[string]*_bintree_t{
        "2015-01-01 120000 create table role.sql": &_bintree_t{test_migrations_2015_01_01_120000_create_table_role_sql, map[string]*_bintree_t{
        }},
        "2015-01-01 120100 create table user.sql": &_bintree_t{test_migrations_2015_01_01_120100_create_table_user_sql, map[string]*_bintree_t{
        }},
        // [...]
    }},
}}
```

When I did it on Windows, it looked like this:

```go
var _bintree = &_bintree_t{nil, map[string]*_bintree_t{
    "test-migrations/2015-01-01 120000 create table role.sql": &_bintree_t{test_migrations_2015_01_01_120000_create_table_role_sql, map[string]*_bintree_t{
    }},
    "test-migrations/2015-01-01 120100 create table user.sql": &_bintree_t{test_migrations_2015_01_01_120100_create_table_user_sql, map[string]*_bintree_t{
    }},
    // [...]
}}
```

This had no consequences for the `Asset()` function, but when I did `AssetDir("test-migrations")`, it failed with an "Asset not found" error when I used an assets file that was generated on Windows.

The problem seems to be that the directory tree is generated by splitting the path names by `os.PathSeparator` which is `\` on Windows. However, as far as I can tell slashes are normalized anyway for all platforms in the `findFiles()` function in `convert.go`, so my fix should not break anything.