### PR TITLE
Always encode binary data to ascii-escaped strings

### DIFF
--- a/release.go
+++ b/release.go
@@ -346,7 +346,7 @@ func uncompressed_memcopy(w io.Writer, asset *Asset, r io.Reader) error {
 	if utf8.Valid(b) {
 		fmt.Fprintf(w, "`%s`", sanitize(b))
 	} else {
-		fmt.Fprintf(w, "%q", b)
+		fmt.Fprintf(w, "%+q", b)
 	}
 
 	_, err = fmt.Fprintf(w, `)


### PR DESCRIPTION
The `%q` format flag behaves differently in go1.3 and go1.4. Some binary data that is escaped in go1.3 (like `\u0de7`) is output as-is in 1.4 (as ෧). This might be because some data that is technically an esoteric (but valid) UTF-8 character was being escaped in go1.3.

Regardless, it was wreaking havoc with diffs when building with different go versions. Using the `%+q` format flag escapes binary data to ASCII escapes, which makes builds using go1.3 and 1.4 match.

@jwforres fyi