### PR TITLE
Implementation for following symlinks

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -2,6 +2,7 @@ package bindata
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -17,11 +18,72 @@ func TestSafeFunctionName(t *testing.T) {
 func TestFindFiles(t *testing.T) {
 	var toc []Asset
 	var knownFuncs = make(map[string]int)
-	err := findFiles("testdata/dupname", "testdata/dupname", true, &toc, []*regexp.Regexp{}, knownFuncs)
+	var visitedPaths = make(map[string]bool)
+	err := findFiles("testdata/dupname", "testdata/dupname", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
 	if toc[0].Func == toc[1].Func {
 		t.Errorf("name collision")
+	}
+}
+
+func TestFindFilesWithSymlinks(t *testing.T) {
+	var tocSrc []Asset
+	var tocTarget []Asset
+
+	var knownFuncs = make(map[string]int)
+	var visitedPaths = make(map[string]bool)
+	err := findFiles("testdata/symlinkSrc", "testdata/symlinkSrc", true, &tocSrc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	if err != nil {
+		t.Errorf("expected to be no error: %+v", err)
+	}
+
+	knownFuncs = make(map[string]int)
+	visitedPaths = make(map[string]bool)
+	err = findFiles("testdata/symlinkParent", "testdata/symlinkParent", true, &tocTarget, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	if err != nil {
+		t.Errorf("expected to be no error: %+v", err)
+	}
+
+	if len(tocSrc) != len(tocTarget) {
+		t.Errorf("Symlink source and target should have the same number of assets.  Expected %d got %d", len(tocTarget), len(tocSrc))
+	} else {
+		for i, _ := range tocSrc {
+			targetFunc := strings.TrimPrefix(tocTarget[i].Func, "symlinktarget_")
+			if tocSrc[i].Func != targetFunc {
+				t.Errorf("Symlink source and target produced different function lists.  Expected %s to be %s", targetFunc, tocSrc[i].Func)
+			}
+		}
+	}
+}
+
+func TestFindFilesWithRecursiveSymlinks(t *testing.T) {
+	var toc []Asset
+
+	var knownFuncs = make(map[string]int)
+	var visitedPaths = make(map[string]bool)
+	err := findFiles("testdata/symlinkRecursiveParent", "testdata/symlinkRecursiveParent", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	if err != nil {
+		t.Errorf("expected to be no error: %+v", err)
+	}
+
+	if len(toc) != 1 {
+		t.Errorf("Only one asset should have been found.  Got %d: %v", len(toc), toc)
+	}
+}
+
+func TestFindFilesWithSymlinkedFile(t *testing.T) {
+	var toc []Asset
+
+	var knownFuncs = make(map[string]int)
+	var visitedPaths = make(map[string]bool)
+	err := findFiles("testdata/symlinkFile", "testdata/symlinkFile", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	if err != nil {
+		t.Errorf("expected to be no error: %+v", err)
+	}
+
+	if len(toc) != 1 {
+		t.Errorf("Only one asset should have been found.  Got %d: %v", len(toc), toc)
 	}
 }

--- a/testdata/symlinkFile/file1
+++ b/testdata/symlinkFile/file1
@@ -1,0 +1,1 @@
+../symlinkSrc/file1

--- a/testdata/symlinkParent/symlinkTarget
+++ b/testdata/symlinkParent/symlinkTarget
@@ -1,0 +1,1 @@
+../symlinkSrc/

--- a/testdata/symlinkRecursiveParent/file1
+++ b/testdata/symlinkRecursiveParent/file1
@@ -1,0 +1,1 @@
+// test file 1

--- a/testdata/symlinkRecursiveParent/symlinkTarget
+++ b/testdata/symlinkRecursiveParent/symlinkTarget
@@ -1,0 +1,1 @@
+../symlinkRecursiveParent/

--- a/testdata/symlinkSrc/file1
+++ b/testdata/symlinkSrc/file1
@@ -1,0 +1,1 @@
+// symlink file 1

--- a/testdata/symlinkSrc/file2
+++ b/testdata/symlinkSrc/file2
@@ -1,0 +1,1 @@
+// symlink file 2

--- a/testdata/symlinkSrc/file3
+++ b/testdata/symlinkSrc/file3
@@ -1,0 +1,1 @@
+// symlink file 3

--- a/testdata/symlinkSrc/file4
+++ b/testdata/symlinkSrc/file4
@@ -1,0 +1,1 @@
+// symlink file 4


### PR DESCRIPTION
Fix for issue #24.  This is an implementation where findFiles will follow symlinks and keep
track of paths already followed.  No paths will be evaluated more than
once, therefore preventing recursive link evaluation.

New tests include testing for recursive symlinks, file symlinks (should be read as normal assets) and simply recursively reading symlinks that haven't already been read.