### PR TITLE
Use `filepath` everywhere instead of `path`

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -34,7 +34,6 @@ func writeDebugHeader(w io.Writer) error {
 	"io/ioutil"
 	"strings"
 	"os"
-	"path"
 	"path/filepath"
 )
 

--- a/release.go
+++ b/release.go
@@ -107,7 +107,6 @@ func header_compressed_nomemcopy(w io.Writer) error {
 	"os"
 	"time"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 )
 
@@ -145,7 +144,6 @@ func header_compressed_memcopy(w io.Writer) error {
 	"os"
 	"time"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 )
 
@@ -182,7 +180,6 @@ func header_uncompressed_nomemcopy(w io.Writer) error {
 	"os"
 	"time"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 )
 
@@ -208,7 +205,6 @@ func header_uncompressed_memcopy(w io.Writer) error {
 	"os"
 	"time"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 )
 `)

--- a/restore.go
+++ b/restore.go
@@ -21,7 +21,7 @@ func RestoreAsset(dir, name string) error {
         if err != nil {
                 return err
         }
-        err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+        err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
         if err != nil {
                 return err
         }
@@ -45,7 +45,7 @@ func RestoreAssets(dir, name string) error {
         }
         // Dir
         for _, child := range children {
-                err = RestoreAssets(dir, path.Join(name, child))
+                err = RestoreAssets(dir, filepath.Join(name, child))
                 if err != nil {
                         return err
                 }

--- a/testdata/out/compress-memcopy.go
+++ b/testdata/out/compress-memcopy.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"time"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 )
 
@@ -278,7 +277,7 @@ func RestoreAsset(dir, name string) error {
         if err != nil {
                 return err
         }
-        err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+        err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
         if err != nil {
                 return err
         }
@@ -302,7 +301,7 @@ func RestoreAssets(dir, name string) error {
         }
         // Dir
         for _, child := range children {
-                err = RestoreAssets(dir, path.Join(name, child))
+                err = RestoreAssets(dir, filepath.Join(name, child))
                 if err != nil {
                         return err
                 }

--- a/testdata/out/compress-nomemcopy.go
+++ b/testdata/out/compress-nomemcopy.go
@@ -13,26 +13,15 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
-	"unsafe"
 	"os"
 	"time"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 )
 
 func bindataRead(data, name string) ([]byte, error) {
-	var empty [0]byte
-	sx := (*reflect.StringHeader)(unsafe.Pointer(&data))
-	b := empty[:]
-	bx := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	bx.Data = sx.Data
-	bx.Len = len(data)
-	bx.Cap = bx.Len
-
-	gz, err := gzip.NewReader(bytes.NewBuffer(b))
+	gz, err := gzip.NewReader(strings.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("Read %q: %v", name, err)
 	}
@@ -288,7 +277,7 @@ func RestoreAsset(dir, name string) error {
         if err != nil {
                 return err
         }
-        err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+        err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
         if err != nil {
                 return err
         }
@@ -312,7 +301,7 @@ func RestoreAssets(dir, name string) error {
         }
         // Dir
         for _, child := range children {
-                err = RestoreAssets(dir, path.Join(name, child))
+                err = RestoreAssets(dir, filepath.Join(name, child))
                 if err != nil {
                         return err
                 }

--- a/testdata/out/debug.go
+++ b/testdata/out/debug.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"strings"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -229,7 +228,7 @@ func RestoreAsset(dir, name string) error {
         if err != nil {
                 return err
         }
-        err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+        err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
         if err != nil {
                 return err
         }
@@ -253,7 +252,7 @@ func RestoreAssets(dir, name string) error {
         }
         // Dir
         for _, child := range children {
-                err = RestoreAssets(dir, path.Join(name, child))
+                err = RestoreAssets(dir, filepath.Join(name, child))
                 if err != nil {
                         return err
                 }

--- a/testdata/out/nocompress-memcopy.go
+++ b/testdata/out/nocompress-memcopy.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"time"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 )
 type asset struct {
@@ -246,7 +245,7 @@ func RestoreAsset(dir, name string) error {
         if err != nil {
                 return err
         }
-        err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+        err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
         if err != nil {
                 return err
         }
@@ -270,7 +269,7 @@ func RestoreAssets(dir, name string) error {
         }
         // Dir
         for _, child := range children {
-                err = RestoreAssets(dir, path.Join(name, child))
+                err = RestoreAssets(dir, filepath.Join(name, child))
                 if err != nil {
                         return err
                 }

--- a/testdata/out/nocompress-nomemcopy.go
+++ b/testdata/out/nocompress-nomemcopy.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"time"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 )
 
@@ -268,7 +267,7 @@ func RestoreAsset(dir, name string) error {
         if err != nil {
                 return err
         }
-        err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+        err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
         if err != nil {
                 return err
         }
@@ -292,7 +291,7 @@ func RestoreAssets(dir, name string) error {
         }
         // Dir
         for _, child := range children {
-                err = RestoreAssets(dir, path.Join(name, child))
+                err = RestoreAssets(dir, filepath.Join(name, child))
                 if err != nil {
                         return err
                 }


### PR DESCRIPTION
For non-slashed paths (e.g. Windows) `path` does the wrong thing.
Sadly this is not documented, but a cursory glance at the go sources
reveals that `filepath` uses `os.PathSeparator` everywhere while
`path` uses a literal `"/"`.