### PR TITLE
call ToSlash() to be slash separated paths also on Windows.

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -64,7 +64,7 @@ func Translate(c *Config) error {
 
 	for _, asset := range toc {
 		relative, _ := filepath.Rel(wd, asset.Path)
-		if _, err = fmt.Fprintf(bfd, "// %s\n", relative); err != nil {
+		if _, err = fmt.Fprintf(bfd, "// %s\n", filepath.ToSlash(relative)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This is only changing comment part.
