### PR TITLE
fix a bug that invalid convert to asset name if recursive

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -173,8 +173,9 @@ func findFiles(dir, prefix string, recursive bool, toc *[]Asset, ignore []*regex
 
 		if file.IsDir() {
 			if recursive {
+				recursivePath := filepath.Join(dir, file.Name())
 				visitedPaths[asset.Path] = true
-				findFiles(asset.Path, prefix, recursive, toc, ignore, knownFuncs, visitedPaths)
+				findFiles(recursivePath, prefix, recursive, toc, ignore, knownFuncs, visitedPaths)
 			}
 			continue
 		} else if file.Mode()&os.ModeSymlink == os.ModeSymlink {


### PR DESCRIPTION
Relate to the #101.