### PR TITLE
Don't write NUL bytes in uncompressed_memcopy()

### DIFF
--- a/release.go
+++ b/release.go
@@ -335,7 +335,7 @@ func uncompressed_memcopy(w io.Writer, asset *Asset, r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if utf8.Valid(b) {
+	if utf8.Valid(b) && !bytes.Contains(b, []byte{0}) {
 		fmt.Fprintf(w, "`%s`", sanitize(b))
 	} else {
 		fmt.Fprintf(w, "%+q", b)


### PR DESCRIPTION
NUL bytes are valid UTF-8 code points, but they're illegal in Go source code and shouldn't be generated by `go-bindata -nocompress`.