### PR TITLE
Allow excluding metadata from built assets

### DIFF
--- a/config.go
+++ b/config.go
@@ -127,6 +127,8 @@ type Config struct {
 	// repository.
 	Dev bool
 
+	// When true, size, mode and modtime are not preserved from files
+	NoMetadata bool
 	// When nonzero, use this as mode for all files.
 	Mode uint
 	// When nonzero, use this as unix timestamp for all files.

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -47,6 +47,7 @@ func parseArgs() *bindata.Config {
 	flag.StringVar(&c.Package, "pkg", c.Package, "Package name to use in the generated code.")
 	flag.BoolVar(&c.NoMemCopy, "nomemcopy", c.NoMemCopy, "Use a .rodata hack to get rid of unnecessary memcopies. Refer to the documentation to see what implications this carries.")
 	flag.BoolVar(&c.NoCompress, "nocompress", c.NoCompress, "Assets will *not* be GZIP compressed when this flag is specified.")
+	flag.BoolVar(&c.NoMetadata, "nometadata", c.NoMetadata, "Assets will not preserve size, mode, and modtime info.")
 	flag.UintVar(&c.Mode, "mode", c.Mode, "Optional file mode override for all files.")
 	flag.Int64Var(&c.ModTime, "modtime", c.ModTime, "Optional modification unix timestamp override for all files.")
 	flag.StringVar(&c.Output, "o", c.Output, "Optional name of the output file to be generated.")

--- a/release.go
+++ b/release.go
@@ -359,7 +359,12 @@ func asset_release_common(w io.Writer, c *Config, asset *Asset) error {
 
 	mode := uint(fi.Mode())
 	modTime := fi.ModTime().Unix()
-
+	size := fi.Size()
+	if c.NoMetadata {
+		mode = 0
+		modTime = 0
+		size = 0
+	}
 	if c.Mode > 0 {
 		mode = uint(os.ModePerm) & c.Mode
 	}
@@ -377,6 +382,6 @@ func asset_release_common(w io.Writer, c *Config, asset *Asset) error {
 	return a, nil
 }
 
-`, asset.Func, asset.Func, asset.Name, fi.Size(), mode, modTime)
+`, asset.Func, asset.Func, asset.Name, size, mode, modTime)
 	return err
 }


### PR DESCRIPTION
When building a bindata file that will be committed to source control, the size and modtime fields are often sources of merge conflicts. If the size, mode, and modtime info isn't being used, it is useful to be able to ignore the metadata fields on files.