### PR TITLE
Add InputConfig.Name to override the asset's name

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,6 +17,9 @@ type InputConfig struct {
 	// in the generated output.
 	Path string
 
+	// Name defines an override of the name of the asset.
+	Name string
+
 	// Recusive defines whether subdirectories of Path
 	// should be recursively included in the conversion.
 	Recursive bool

--- a/convert_test.go
+++ b/convert_test.go
@@ -19,7 +19,7 @@ func TestFindFiles(t *testing.T) {
 	var toc []Asset
 	var knownFuncs = make(map[string]int)
 	var visitedPaths = make(map[string]bool)
-	err := findFiles("testdata/dupname", "testdata/dupname", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err := findFiles("testdata/dupname", "", "testdata/dupname", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
@@ -34,14 +34,14 @@ func TestFindFilesWithSymlinks(t *testing.T) {
 
 	var knownFuncs = make(map[string]int)
 	var visitedPaths = make(map[string]bool)
-	err := findFiles("testdata/symlinkSrc", "testdata/symlinkSrc", true, &tocSrc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err := findFiles("testdata/symlinkSrc", "", "testdata/symlinkSrc", true, &tocSrc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
 
 	knownFuncs = make(map[string]int)
 	visitedPaths = make(map[string]bool)
-	err = findFiles("testdata/symlinkParent", "testdata/symlinkParent", true, &tocTarget, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err = findFiles("testdata/symlinkParent", "", "testdata/symlinkParent", true, &tocTarget, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
@@ -64,7 +64,7 @@ func TestFindFilesWithRecursiveSymlinks(t *testing.T) {
 
 	var knownFuncs = make(map[string]int)
 	var visitedPaths = make(map[string]bool)
-	err := findFiles("testdata/symlinkRecursiveParent", "testdata/symlinkRecursiveParent", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err := findFiles("testdata/symlinkRecursiveParent", "", "testdata/symlinkRecursiveParent", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
@@ -79,12 +79,47 @@ func TestFindFilesWithSymlinkedFile(t *testing.T) {
 
 	var knownFuncs = make(map[string]int)
 	var visitedPaths = make(map[string]bool)
-	err := findFiles("testdata/symlinkFile", "testdata/symlinkFile", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err := findFiles("testdata/symlinkFile", "", "testdata/symlinkFile", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
 
 	if len(toc) != 1 {
 		t.Errorf("Only one asset should have been found.  Got %d: %v", len(toc), toc)
+	}
+}
+
+func TestFindFilesWithName(t *testing.T) {
+	var toc []Asset
+	var knownFuncs = make(map[string]int)
+	var visitedPaths = make(map[string]bool)
+	err := findFiles("testdata/dupname/foo_bar", "baz", "", false, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	if err != nil {
+		t.Errorf("expected to be no error: %+v", err)
+	}
+	if len(toc) != 1 {
+		t.Errorf("Only one asset should have been found.  Got %d: %+v", len(toc), toc)
+	}
+	if toc[0].Name != "baz" {
+		t.Errorf("Expected renamed asset.  Got: %+v", toc[0])
+	}
+}
+
+func TestFindFilesWithNameRecursive(t *testing.T) {
+	var toc []Asset
+	var knownFuncs = make(map[string]int)
+	var visitedPaths = make(map[string]bool)
+	err := findFiles("testdata/dupname", "baz", "", true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	if err != nil {
+		t.Errorf("expected to be no error: %+v", err)
+	}
+	if len(toc) != 2 {
+		t.Errorf("Only two assets should have been found.  Got %d: %+v", len(toc), toc)
+	}
+	if toc[0].Name != "baz/foo/bar" {
+		t.Errorf("Expected renamed asset.  Got: %+v", toc[0])
+	}
+	if toc[1].Name != "baz/foo_bar" {
+		t.Errorf("Expected renamed asset.  Got: %+v", toc[1])
 	}
 }


### PR DESCRIPTION
Given a non-recursive path to a file, InputConfig.Name will fully
override the Asset.Name value.

If a recursive path to a directory is given, InputConfig.Name will act
as a prefix for all assets under that path.

Fixes #111.