### PR TITLE
Alter `-prefix` to Use Regular Expressions instead of just strings. Issue #129

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,13 @@ The default behaviour of the program is to use compression.
 
 ### Path prefix stripping
 
-The keys used in the `_bindata` map, are the same as the input file name
-passed to `go-bindata`. This includes the path. In most cases, this is not
-desireable, as it puts potentially sensitive information in your code base.
-For this purpose, the tool supplies another command line flag `-prefix`.
-This accepts a portion of a path name, which should be stripped off from
-the map keys and function names.
+The keys used in the `_bindata` map are the same as the input file name passed
+to `go-bindata`. This includes the path. In most cases, this is not desireable,
+as it puts potentially sensitive information in your code base.  For this
+purpose, the tool supplies another command line flag `-prefix`.  This accepts a
+[regular expression](https://github.com/google/re2/wiki/Syntax) string, which
+will be used to match a portion of the map keys and function names that should
+be stripped out.
 
 For example, running without the `-prefix` flag, we get:
 
@@ -167,7 +168,7 @@ For example, running without the `-prefix` flag, we get:
 
 Running with the `-prefix` flag, we get:
 
-	$ go-bindata -prefix "/path/to/" /path/to/templates/
+	$ go-bindata -prefix "/.*/some/" /a/path/to/some/templates/
 
 	_bindata["templates/foo.html"] = templates_foo_html
 

--- a/config.go
+++ b/config.go
@@ -42,17 +42,17 @@ type Config struct {
 	// working directory.
 	Output string
 
-	// Prefix defines a path prefix which should be stripped from all
-	// file names when generating the keys in the table of contents.
-	// For example, running without the `-prefix` flag, we get:
+	// Prefix defines a regular expression which should used to strip
+	// substrings from all file names when generating the keys in the table of
+	// contents.  For example, running without the `-prefix` flag, we get:
 	//
 	// 	$ go-bindata /path/to/templates
 	// 	go_bindata["/path/to/templates/foo.html"] = _path_to_templates_foo_html
 	//
-	// Running with the `-prefix` flag, we get:
+	//	Running with the `-prefix` flag, we get:
 	//
-	// 	$ go-bindata -prefix "/path/to/" /path/to/templates/foo.html
-	// 	go_bindata["templates/foo.html"] = templates_foo_html
+	//	$ go-bindata -prefix "/.*/some/" /a/path/to/some/templates/
+	//	_bindata["templates/foo.html"] = templates_foo_html
 	Prefix *regexp.Regexp
 
 	// NoMemCopy will alter the way the output file is generated.

--- a/config.go
+++ b/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	//
 	// 	$ go-bindata -prefix "/path/to/" /path/to/templates/foo.html
 	// 	go_bindata["templates/foo.html"] = templates_foo_html
-	Prefix string
+	Prefix *regexp.Regexp
 
 	// NoMemCopy will alter the way the output file is generated.
 	//

--- a/convert.go
+++ b/convert.go
@@ -119,13 +119,8 @@ func (v ByName) Less(i, j int) bool { return v[i].Name() < v[j].Name() }
 // findFiles recursively finds all the file paths in the given directory tree.
 // They are added to the given map as keys. Values will be safe function names
 // for each file, which will be used when generating the output code.
-func findFiles(dir, prefix string, recursive bool, toc *[]Asset, ignore []*regexp.Regexp, knownFuncs map[string]int, visitedPaths map[string]bool) error {
+func findFiles(dir string, prefix *regexp.Regexp, recursive bool, toc *[]Asset, ignore []*regexp.Regexp, knownFuncs map[string]int, visitedPaths map[string]bool) error {
 	dirpath := dir
-	if len(prefix) > 0 {
-		dirpath, _ = filepath.Abs(dirpath)
-		prefix, _ = filepath.Abs(prefix)
-		prefix = filepath.ToSlash(prefix)
-	}
 
 	fi, err := os.Stat(dirpath)
 	if err != nil {
@@ -195,8 +190,8 @@ func findFiles(dir, prefix string, recursive bool, toc *[]Asset, ignore []*regex
 			continue
 		}
 
-		if strings.HasPrefix(asset.Name, prefix) {
-			asset.Name = asset.Name[len(prefix):]
+		if prefix != nil && prefix.MatchString(asset.Name) {
+			asset.Name = prefix.ReplaceAllString(asset.Name, "")
 		} else {
 			asset.Name = filepath.Join(dir, file.Name())
 		}

--- a/doc.go
+++ b/doc.go
@@ -95,12 +95,13 @@ The default behaviour of the program is to use compression.
 
 Path prefix stripping
 
-The keys used in the `_bindata` map are the same as the input file name
-passed to `go-bindata`. This includes the path. In most cases, this is not
-desireable, as it puts potentially sensitive information in your code base.
-For this purpose, the tool supplies another command line flag `-prefix`.
-This accepts a portion of a path name, which should be stripped off from
-the map keys and function names.
+The keys used in the `_bindata` map are the same as the input file name passed
+to `go-bindata`. This includes the path. In most cases, this is not desireable,
+as it puts potentially sensitive information in your code base.  For this
+purpose, the tool supplies another command line flag `-prefix`.  This accepts a
+[regular expression](https://github.com/google/re2/wiki/Syntax) string, which
+will be used to match a portion of the map keys and function names that should
+be stripped out.
 
 For example, running without the `-prefix` flag, we get:
 
@@ -110,7 +111,7 @@ For example, running without the `-prefix` flag, we get:
 
 Running with the `-prefix` flag, we get:
 
-	$ go-bindata -prefix "/path/to/" /path/to/templates/
+	$ go-bindata -prefix "/.*\/some/" /a/path/to/some/templates/
 
 	_bindata["templates/foo.html"] = templates_foo_html
 

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -32,6 +32,7 @@ func main() {
 // any of the command line options are incorrect.
 func parseArgs() *bindata.Config {
 	var version bool
+	var rawPrefix string
 
 	c := bindata.NewConfig()
 
@@ -43,13 +44,13 @@ func parseArgs() *bindata.Config {
 	flag.BoolVar(&c.Debug, "debug", c.Debug, "Do not embed the assets, but provide the embedding API. Contents will still be loaded from disk.")
 	flag.BoolVar(&c.Dev, "dev", c.Dev, "Similar to debug, but does not emit absolute paths. Expects a rootDir variable to already exist in the generated code's package.")
 	flag.StringVar(&c.Tags, "tags", c.Tags, "Optional set of build tags to include.")
-	flag.StringVar(&c.Prefix, "prefix", c.Prefix, "Optional path prefix to strip off asset names.")
 	flag.StringVar(&c.Package, "pkg", c.Package, "Package name to use in the generated code.")
 	flag.BoolVar(&c.NoMemCopy, "nomemcopy", c.NoMemCopy, "Use a .rodata hack to get rid of unnecessary memcopies. Refer to the documentation to see what implications this carries.")
 	flag.BoolVar(&c.NoCompress, "nocompress", c.NoCompress, "Assets will *not* be GZIP compressed when this flag is specified.")
 	flag.BoolVar(&c.NoMetadata, "nometadata", c.NoMetadata, "Assets will not preserve size, mode, and modtime info.")
 	flag.UintVar(&c.Mode, "mode", c.Mode, "Optional file mode override for all files.")
 	flag.Int64Var(&c.ModTime, "modtime", c.ModTime, "Optional modification unix timestamp override for all files.")
+	flag.StringVar(&rawPrefix, "prefix", "", "Optional path prefix to strip off asset names.")
 	flag.StringVar(&c.Output, "o", c.Output, "Optional name of the output file to be generated.")
 	flag.BoolVar(&version, "version", false, "Displays version information.")
 
@@ -57,6 +58,17 @@ func parseArgs() *bindata.Config {
 	flag.Var((*AppendSliceValue)(&ignore), "ignore", "Regex pattern to ignore")
 
 	flag.Parse()
+
+	if rawPrefix != "" {
+		var err error
+		c.Prefix, err = regexp.Compile(rawPrefix)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to understand -prefix regex pattern.\n")
+			os.Exit(1)
+		}
+	} else {
+		c.Prefix = nil
+	}
 
 	patterns := make([]*regexp.Regexp, 0)
 	for _, pattern := range ignore {


### PR DESCRIPTION
The diff should summarize the changes pretty well. This didn't take many.

The `-prefix` option now takes in a regular expression and uses that to filter out portions of the paths.

See:
https://github.com/jteeuwen/go-bindata/issues/129