### PR TITLE
update build info with newer golang

### DIFF
--- a/go-bindata/version.go
+++ b/go-bindata/version.go
@@ -18,7 +18,8 @@ const (
 // revision part of the program version.
 // This will be set automatically at build time like so:
 //
-//     go build -ldflags "-X main.AppVersionRev `date -u +%s`"
+//     go build -ldflags "-X main.AppVersionRev `date -u +%s`" (go version < 1.5)
+//     go build -ldflags "-X main.AppVersionRev=`date -u +%s`" (go version >= 1.5)
 var AppVersionRev string
 
 func Version() string {


### PR DESCRIPTION
As stated in the Golang release info for [Golang 1.5](https://golang.org/doc/go1.5) and [Golang 1.6](https://golang.org/doc/go1.6). Searching for 'importpath.name', the release info in Golang 1.6 said that:

> As a reminder, the linker's -X flag changed in Go 1.5. In Go 1.4 and earlier, it took two arguments, as in

> `-X importpath.name value`
> Go 1.5 added an alternative syntax using a single argument that is itself a name=value pair:

> `-X importpath.name=value`
> In Go 1.5 the old syntax was still accepted, after printing a warning suggesting use of the new syntax instead. Go 1.6 continues to accept the old syntax and print the warning. Go 1.7 will remove support for the old syntax.

So, the old build command line:
`go build -ldflags "-X main.AppVersionRev `date -u +%s`"` will not function properly in Go 1.7.
so i think we should update the build info for newer Golang. :)
