### PR TITLE
Fix generated code for accessing assets to return standard error types

### DIFF
--- a/toc.go
+++ b/toc.go
@@ -114,12 +114,12 @@ func AssetDir(name string) ([]string, error) {
 		for _, p := range pathList {
 			node = node.Children[p]
 			if node == nil {
-				return nil, fmt.Errorf("Asset %%s not found", name)
+				return nil, &os.PathError{"open", name, os.ErrNotExist}
 			}
 		}
 	}
 	if node.Func != nil {
-		return nil, fmt.Errorf("Asset %%s not found", name)
+		return nil, &os.PathError{"open", name, os.ErrNotExist}
 	}
 	rv := make([]string, 0, len(node.Children))
 	for childName := range node.Children {
@@ -171,7 +171,7 @@ func Asset(name string) ([]byte, error) {
 		}
 		return a.bytes, nil
 	}
-	return nil, fmt.Errorf("Asset %%s not found", name)
+	return nil, &os.PathError{"open", name, os.ErrNotExist}
 }
 
 // MustAsset is like Asset but panics when Asset would return an error.
@@ -197,7 +197,7 @@ func AssetInfo(name string) (os.FileInfo, error) {
 		}
 		return a.info, nil
 	}
-	return nil, fmt.Errorf("AssetInfo %%s not found", name)
+	return nil, &os.PathError{"open", name, os.ErrNotExist}
 }
 
 // AssetNames returns the names of the assets.


### PR DESCRIPTION
This enables an assetfs from github.com/elazarl/go-bindata-assetfs to be
passed directly to a http.FileServer and have the HTTP server return
404s rather than 500s for missing files.

cc @tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jteeuwen/go-bindata/136)
<!-- Reviewable:end -->
