### PR TITLE
Add '-include' regex patterns

### DIFF
--- a/config.go
+++ b/config.go
@@ -139,7 +139,8 @@ type Config struct {
 	// will match any .gitignore file.
 	//
 	// This parameter can be provided multiple times.
-	Ignore []*regexp.Regexp
+	Ignore  []*regexp.Regexp
+	Include []*regexp.Regexp
 }
 
 // NewConfig returns a default configuration struct.
@@ -151,6 +152,7 @@ func NewConfig() *Config {
 	c.Debug = false
 	c.Output = "./bindata.go"
 	c.Ignore = make([]*regexp.Regexp, 0)
+	c.Include = make([]*regexp.Regexp, 0)
 	return c
 }
 

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -56,13 +56,18 @@ func parseArgs() *bindata.Config {
 	ignore := make([]string, 0)
 	flag.Var((*AppendSliceValue)(&ignore), "ignore", "Regex pattern to ignore")
 
+	include := make([]stirng, 0)
+	flag.Var((*AppendSliceValue)(&include), "include", "Regex pattern to include")
+
 	flag.Parse()
 
-	patterns := make([]*regexp.Regexp, 0)
 	for _, pattern := range ignore {
-		patterns = append(patterns, regexp.MustCompile(pattern))
+		c.Ignore = append(c.Ignore, regexp.MustCompile(pattern))
 	}
-	c.Ignore = patterns
+
+	for _, pattern := range include {
+		c.Include = append(c.Include, regexp.MustCompile(pattern))
+	}
 
 	if version {
 		fmt.Printf("%s\n", Version())


### PR DESCRIPTION
Support `-include <regex>` which is similar to `-ignore` with the opposite meaning.
`-include` overrides the matching decisions made by `-ignore`.