### PR TITLE
Multiline bindata

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+; Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace  = true
+insert_final_newline = true
+charset = utf-8
+
+; Golang
+[{*.go,Makefile}]
+indent_style = tab
+
+; JSON, YAML, and Go templates
+[*.{json,tmpl,yaml,yml}]
+indent_size = 2

--- a/release.go
+++ b/release.go
@@ -248,7 +248,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 }
 
 func compressed_nomemcopy(w io.Writer, asset *Asset, r io.Reader) error {
-	_, err := fmt.Fprintf(w, `var _%s = "`, asset.Func)
+	_, err := fmt.Fprintf(w, "var _%s =\n\t\"", asset.Func)
 	if err != nil {
 		return err
 	}
@@ -275,7 +275,7 @@ func %sBytes() ([]byte, error) {
 }
 
 func compressed_memcopy(w io.Writer, asset *Asset, r io.Reader) error {
-	_, err := fmt.Fprintf(w, `var _%s = []byte("`, asset.Func)
+	_, err := fmt.Fprintf(w, "var _%s = []byte(\n\t\"", asset.Func)
 	if err != nil {
 		return err
 	}

--- a/stringwriter.go
+++ b/stringwriter.go
@@ -28,6 +28,11 @@ func (w *StringWriter) Write(p []byte) (n int, err error) {
 		buf[3] = lowerHex[b%16]
 		w.Writer.Write(buf)
 		w.c++
+
+		// 28 fits nicely with tab width at 4 and a 120 char line limit
+		if w.c % 28 == 0 {
+			w.Writer.Write([]byte("\" +\n\t\""))
+		}
 	}
 
 	n++


### PR DESCRIPTION
Many dev tools currently have or previously had issues handling files with extremely long lines. Obviously this is a recurring issue, so such long lines should be avoided when possible. This change breaks the binary data up into multiple lines, so as not to cause problems. Generated assembly is identical (as tested with the output of `go tool compile -S -S` on generated `.go` files) as the compiler optimizes away the string concatenations, so `-nomemcopy` is unaffected.