### PR TITLE
Make the output file compatible with gofmt.

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -57,7 +57,6 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-
 `)
 	return err
 }

--- a/toc.go
+++ b/toc.go
@@ -87,6 +87,7 @@ func (root *assetTree) WriteAsGoMap(w io.Writer) error {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = `)
 	root.writeGoMap(w, 0)
 	return err
@@ -148,6 +149,10 @@ func writeTOC(w io.Writer, toc []Asset) error {
 	}
 
 	for i := range toc {
+		if i != 0 {
+			// Newlines between elements make gofmt happy.
+			w.Write([]byte{'\n'})
+		}
 		err = writeTOCAsset(w, &toc[i])
 		if err != nil {
 			return err


### PR DESCRIPTION
With this change, running gofmt on the file will not change the file.