### PR TITLE
Simplify RestoreAsset

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -29,11 +29,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.Chtimes(_filePath(dir, name), info.ModTime(), info.ModTime())
-	if err != nil {
-		return err
-	}
-	return nil
+	return os.Chtimes(_filePath(dir, name), info.ModTime(), info.ModTime())
 }
 
 // RestoreAssets restores an asset under the given directory recursively


### PR DESCRIPTION
This makes the `simplify` check from https://github.com/dominikh/go-tools pass: `'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013)`